### PR TITLE
Support for pending state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/etc/build/.gitignore
 
 /tests/Application/yarn.lock
+/tests/Application/shipping_labels
 
 /.phpunit.result.cache
 /behat.yml

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "bitbag/shipping-export-plugin": "^1.5",
+        "bitbag/shipping-export-plugin": "^1.6",
         "sylius/sylius": "~1.9.0 || ~1.10.0"
     },
     "require-dev": {

--- a/spec/EventListener/ShippingExportEventListener/InPostShippingExportActionProviderSpec.php
+++ b/spec/EventListener/ShippingExportEventListener/InPostShippingExportActionProviderSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace spec\BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportActionInterface;
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportActionProvider;
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportActionProviderInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+final class InPostShippingExportActionProviderSpec extends ObjectBehavior
+{
+    private const FOO = 'foo';
+
+    function let(
+        InPostShippingExportActionInterface $action1,
+        InPostShippingExportActionInterface $action2
+    ): void {
+        $this->beConstructedWith([$action1, $action2]);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(InPostShippingExportActionProvider::class);
+        $this->shouldBeAnInstanceOf(InPostShippingExportActionProviderInterface::class);
+    }
+
+    function it_should_throw_exception_if_no_action_supports_passed_status_code(
+        InPostShippingExportActionInterface $action1,
+        InPostShippingExportActionInterface $action2
+    ): void {
+        $action1->supports(Argument::type('string'))->willReturn(false);
+        $action2->supports(Argument::type('string'))->willReturn(false);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('provide', [self::FOO]);
+    }
+
+    function it_should_return_first_supported_action(
+        InPostShippingExportActionInterface $action1,
+        InPostShippingExportActionInterface $action2
+    ): void {
+        $action1->supports(Argument::type('string'))->willReturn(true);
+        $action2->supports(Argument::type('string'))->willReturn(true);
+
+        $this->provide(self::FOO)->shouldReturn($action1);
+    }
+}

--- a/spec/EventListener/ShippingExportEventListener/InPostShippingExportConfirmedActionSpec.php
+++ b/spec/EventListener/ShippingExportEventListener/InPostShippingExportConfirmedActionSpec.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace spec\BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use BitBag\SyliusInPostPlugin\Api\WebClientInterface;
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportActionInterface;
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportConfirmedAction;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
+use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Tests\BitBag\SyliusInPostPlugin\Spec\Builder\OrderBuilder;
+use Tests\BitBag\SyliusInPostPlugin\Spec\Builder\ShipmentBuilder;
+use Tests\BitBag\SyliusInPostPlugin\Spec\Builder\ShippingExportBuilder;
+use Webmozart\Assert\InvalidArgumentException;
+
+class InPostShippingExportConfirmedActionSpec extends ObjectBehavior
+{
+    private const SHIPPING_LABELS_PATH = '/srv/shipping_labels';
+
+    private const SHIPPING_LABEL_CONTENT = '<MY_CONTENT>';
+
+    private const FOO = 'foo';
+
+    private const CONFIRMED = 'confirmed';
+
+    private const SHIPMENT_ID = 1;
+
+    private const ORDER_NUMBER = '0000000001';
+
+    function let(
+        ShippingExportRepositoryInterface $shippingExportRepository,
+        WebClientInterface $webClient,
+        Filesystem $filesystem,
+        FlashBagInterface $flashBag
+    ): void {
+        $this->beConstructedWith($shippingExportRepository, $webClient, $filesystem, $flashBag, self::SHIPPING_LABELS_PATH);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(InPostShippingExportConfirmedAction::class);
+        $this->shouldBeAnInstanceOf(InPostShippingExportActionInterface::class);
+    }
+
+    function it_should_support_the_correct_status_code(): void
+    {
+        $this->supports(self::CONFIRMED)->shouldReturn(true);
+    }
+
+    function it_should_not_support_the_incorrect_status_code(): void
+    {
+        $this->supports(self::FOO)->shouldReturn(false);
+    }
+
+    function it_should_throw_exception_if_shipment_external_id_is_null(): void
+    {
+        $shippingExport = ShippingExportBuilder::create()->build();
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$shippingExport]);
+    }
+
+    function it_should_throw_exception_if_shipment_is_null(): void
+    {
+        $shippingExport = ShippingExportBuilder::create()->withExternalId(self::FOO)->build();
+
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$shippingExport]);
+    }
+
+    function it_should_throw_exception_if_order_is_null(): void
+    {
+        $shipment = ShipmentBuilder::create()->build();
+        $shippingExport = ShippingExportBuilder::create()
+            ->withExternalId(self::FOO)
+            ->withShipment($shipment)
+            ->build();
+
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$shippingExport]);
+    }
+
+    function it_should_throw_exception_if_order_number_is_null(): void
+    {
+        $order = OrderBuilder::create()->build();
+        $shipment = ShipmentBuilder::create()->withOrder($order)->build();
+        $shippingExport = ShippingExportBuilder::create()
+            ->withExternalId(self::FOO)
+            ->withShipment($shipment)
+            ->build();
+
+        $this
+            ->shouldThrow(InvalidArgumentException::class)
+            ->during('execute', [$shippingExport]);
+    }
+
+    function it_should_save_label_under_the_correct_path(
+        WebClientInterface $webClient,
+        ShipmentInterface $shipment,
+        Filesystem $filesystem
+    ): void {
+        $order = OrderBuilder::create()->withNumber(self::ORDER_NUMBER)->build();
+        $shipment->getOrder()->willReturn($order);
+        $shipment->getId()->willReturn(self::SHIPMENT_ID);
+        $shippingExport = ShippingExportBuilder::create()
+            ->withExternalId(self::FOO)
+            ->withShipment($shipment->getWrappedObject())
+            ->build();
+
+        $webClient->getLabels([self::FOO])->willReturn(self::SHIPPING_LABEL_CONTENT);
+
+        $expectedPath = sprintf('%s/%s_%s.pdf', self::SHIPPING_LABELS_PATH, self::SHIPMENT_ID, self::ORDER_NUMBER);
+        $filesystem->dumpFile($expectedPath, self::SHIPPING_LABEL_CONTENT)->shouldBeCalled();
+
+        $this->execute($shippingExport);
+    }
+
+    function it_should_update_shipping_export_entity(
+        WebClientInterface $webClient,
+        ShippingExportRepositoryInterface $shippingExportRepository,
+        ShipmentInterface $shipment,
+        ShippingExportInterface $shippingExport
+    ): void {
+        $webClient->getLabels([self::FOO])->willReturn(self::SHIPPING_LABEL_CONTENT);
+        $order = OrderBuilder::create()->withNumber(self::ORDER_NUMBER)->build();
+        $shipment->getOrder()->willReturn($order);
+        $shipment->getId()->willReturn(self::SHIPMENT_ID);
+        $shippingExport->getExternalId()->willReturn(self::FOO);
+        $shippingExport->getShipment()->willReturn($shipment->getWrappedObject());
+
+        $shippingExport->setLabelPath(Argument::type('string'))->shouldBeCalled();
+        $shippingExport->setState(ShippingExportInterface::STATE_EXPORTED)->shouldBeCalled();
+        $shippingExport->setExportedAt(Argument::type(\DateTime::class))->shouldBeCalled();
+        $shippingExportRepository->add($shippingExport)->shouldBeCalled();
+
+        $this->execute($shippingExport);
+    }
+}

--- a/spec/EventListener/ShippingExportEventListener/InPostShippingExportDefaultActionSpec.php
+++ b/spec/EventListener/ShippingExportEventListener/InPostShippingExportDefaultActionSpec.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace spec\BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportActionInterface;
+use BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportDefaultAction;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
+use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+class InPostShippingExportDefaultActionSpec extends ObjectBehavior
+{
+    private const FOO = 'foo';
+
+    function let(ShippingExportRepositoryInterface $shippingExportRepository, FlashBagInterface $flashBag): void
+    {
+        $this->beConstructedWith($shippingExportRepository, $flashBag);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(InPostShippingExportDefaultAction::class);
+        $this->shouldBeAnInstanceOf(InPostShippingExportActionInterface::class);
+    }
+
+    function it_should_set_state_and_exported_at_properties(ShippingExportInterface $shippingExport): void
+    {
+        $shippingExport->setState(ShippingExportInterface::STATE_PENDING)->shouldBeCalled();
+        $shippingExport->setExportedAt(Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->execute($shippingExport);
+    }
+
+    function it_should_save_shipping_export_changes(
+        ShippingExportInterface $shippingExport,
+        ShippingExportRepositoryInterface $shippingExportRepository
+    ): void {
+        $shippingExportRepository->add($shippingExport)->shouldBeCalled();
+
+        $this->execute($shippingExport);
+    }
+
+    function it_should_always_support(): void
+    {
+        $this->supports(self::FOO)->shouldReturn(true);
+    }
+}

--- a/src/EventListener/ShippingExportEventListener/InPostShippingExportActionInterface.php
+++ b/src/EventListener/ShippingExportEventListener/InPostShippingExportActionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
+
+interface InPostShippingExportActionInterface
+{
+    public function execute(ShippingExportInterface $shippingExport): void;
+
+    public function supports(string $statusCode): bool;
+}

--- a/src/EventListener/ShippingExportEventListener/InPostShippingExportActionProvider.php
+++ b/src/EventListener/ShippingExportEventListener/InPostShippingExportActionProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use Webmozart\Assert\Assert;
+
+final class InPostShippingExportActionProvider implements InPostShippingExportActionProviderInterface
+{
+    private const NO_ACTION_FOUND = 'No action found for status code "%s"';
+
+    /**
+     * @var object[]
+     */
+    public array $actions;
+
+    public function __construct(iterable $actions)
+    {
+        $this->actions = $actions instanceof \Traversable ? iterator_to_array($actions) : $actions;
+    }
+
+    public function provide(string $statusCode): InPostShippingExportActionInterface
+    {
+        foreach ($this->actions as $action) {
+            Assert::isInstanceOf($action, InPostShippingExportActionInterface::class);
+
+            if (!$action->supports($statusCode)) {
+                continue;
+            }
+
+            return $action;
+        }
+
+        throw new \InvalidArgumentException(sprintf(self::NO_ACTION_FOUND, $statusCode));
+    }
+}

--- a/src/EventListener/ShippingExportEventListener/InPostShippingExportActionProviderInterface.php
+++ b/src/EventListener/ShippingExportEventListener/InPostShippingExportActionProviderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+interface InPostShippingExportActionProviderInterface
+{
+    public function provide(string $statusCode): InPostShippingExportActionInterface;
+}

--- a/src/EventListener/ShippingExportEventListener/InPostShippingExportConfirmedAction.php
+++ b/src/EventListener/ShippingExportEventListener/InPostShippingExportConfirmedAction.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use BitBag\SyliusInPostPlugin\Api\WebClientInterface;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
+use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
+use GuzzleHttp\Exception\ClientException;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Webmozart\Assert\Assert;
+
+final class InPostShippingExportConfirmedAction implements InPostShippingExportActionInterface
+{
+    private const CONFIRMED = 'confirmed';
+
+    private const LABEL_EXTENSION = 'pdf';
+
+    private const SUCCESS = 'success';
+
+    private const TRANSLATION_KEY = 'bitbag.ui.shipment_data_has_been_exported';
+
+    private ShippingExportRepositoryInterface $shippingExportRepository;
+
+    private WebClientInterface $webClient;
+
+    private Filesystem $filesystem;
+
+    private FlashBagInterface $flashBag;
+
+    private string $shippingLabelsPath;
+
+    public function __construct(
+        ShippingExportRepositoryInterface $shippingExportRepository,
+        WebClientInterface $webClient,
+        Filesystem $filesystem,
+        FlashBagInterface $flashBag,
+        string $shippingLabelsPath
+    ) {
+        $this->shippingExportRepository = $shippingExportRepository;
+        $this->webClient = $webClient;
+        $this->filesystem = $filesystem;
+        $this->flashBag = $flashBag;
+        $this->shippingLabelsPath = $shippingLabelsPath;
+    }
+
+    /**
+     * @throws ClientException
+     */
+    public function execute(ShippingExportInterface $shippingExport): void
+    {
+        $this->validateShippingExport($shippingExport);
+
+        $label = $this->webClient->getLabels([$shippingExport->getExternalId()]);
+        Assert::notNull($label, 'Label cannot be null');
+        $labelPath = $this->getShippingLabelPath($shippingExport);
+        $shippingExport->setLabelPath($labelPath);
+
+        $this->filesystem->dumpFile($labelPath, $label);
+
+        $shippingExport->setState(ShippingExportInterface::STATE_EXPORTED);
+        $shippingExport->setExportedAt(new \DateTime());
+
+        $this->shippingExportRepository->add($shippingExport);
+        $this->flashBag->add(self::SUCCESS, self::TRANSLATION_KEY);
+    }
+
+    private function validateShippingExport(ShippingExportInterface $shippingExport): void
+    {
+        Assert::notNull($shippingExport->getExternalId(), 'Shipping export external id cannot be null');
+        Assert::notNull($shippingExport->getShipment(), 'Shipment cannot be null');
+        Assert::notNull($shippingExport->getShipment()->getOrder(), 'Order cannot be null');
+        Assert::notNull($shippingExport->getShipment()->getOrder()->getNumber(), 'Order number cannot be null');
+    }
+
+    private function getShippingLabelPath(ShippingExportInterface $shippingExport): string
+    {
+        return sprintf('%s/%s.%s', $this->shippingLabelsPath, $this->getFilename($shippingExport), self::LABEL_EXTENSION);
+    }
+
+    private function getFilename(ShippingExportInterface $shippingExport): string
+    {
+        /** @var ShipmentInterface $shipment */
+        $shipment = $shippingExport->getShipment();
+        /** @var OrderInterface $order */
+        $order = $shipment->getOrder();
+
+        return implode(
+            '_',
+            [
+                $shipment->getId(),
+                $order->getNumber(),
+            ]
+        );
+    }
+
+    public function supports(string $statusCode): bool
+    {
+        return self::CONFIRMED === $statusCode;
+    }
+}

--- a/src/EventListener/ShippingExportEventListener/InPostShippingExportDefaultAction.php
+++ b/src/EventListener/ShippingExportEventListener/InPostShippingExportDefaultAction.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener;
+
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
+use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+final class InPostShippingExportDefaultAction implements InPostShippingExportActionInterface
+{
+    private const INFO = 'info';
+
+    private const TRANSLATION_KEY = 'bitbag.ui.shipment_data_has_been_marked_as_pending';
+
+    private ShippingExportRepositoryInterface $shippingExportRepository;
+
+    private FlashBagInterface $flashBag;
+
+    public function __construct(ShippingExportRepositoryInterface $shippingExportRepository, FlashBagInterface $flashBag)
+    {
+        $this->shippingExportRepository = $shippingExportRepository;
+        $this->flashBag = $flashBag;
+    }
+
+    public function execute(ShippingExportInterface $shippingExport): void
+    {
+        $shippingExport->setState(ShippingExportInterface::STATE_PENDING);
+        $shippingExport->setExportedAt(new \DateTime());
+
+        $this->shippingExportRepository->add($shippingExport);
+
+        $this->flashBag->add(self::INFO, self::TRANSLATION_KEY);
+    }
+
+    public function supports(string $statusCode): bool
+    {
+        return true;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,11 +17,10 @@
                 class="BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener"
                 id="bitbag.sylius_inpost_plugin.event_listener.inpost_shipping_export"
         >
-            <argument type="service" id="doctrine.orm.default_entity_manager"/>
-            <argument type="service" id="session.flash_bag"/>
             <argument type="service" id="bitbag.sylius_inpost_plugin.api.web_client"/>
-            <argument type="service" id="filesystem"/>
-            <argument key="$shippingLabelsPath">%bitbag.shipping_labels_path%</argument>
+            <argument type="service" id="bitbag.sylius_inpost_plugin.provider.inpost_shipping_export_action"/>
+            <argument type="service" id="session.flash_bag"/>
+            <argument type="service" id="logger"/>
 
             <tag name="kernel.event_listener" event="bitbag.shipping_export.export_shipment" method="exportShipment"/>
         </service>

--- a/src/Resources/config/services/inpost_shipping_export_action.xml
+++ b/src/Resources/config/services/inpost_shipping_export_action.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+  ~ This file was created by developers working at BitBag
+  ~ Do you need more information about us and what we do? Visit our https://bitbag.io website!
+  ~ We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+  -->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service
+                id="bitbag.sylius_inpost_plugin.inpost_shipping_export_action.confirmed"
+                class="BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportConfirmedAction"
+        >
+            <argument type="service" id="bitbag.repository.shipping_export" />
+            <argument type="service" id="bitbag.sylius_inpost_plugin.api.web_client"/>
+            <argument type="service" id="filesystem"/>
+            <argument type="service" id="session.flash_bag" />
+            <argument key="$shippingLabelsPath">%bitbag.shipping_labels_path%</argument>
+
+            <tag name="bitbag.inpost_shipping_export_action" />
+        </service>
+
+        <service
+                id="bitbag.sylius_inpost_plugin.inpost_shipping_export_action.default"
+                class="BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportDefaultAction"
+        >
+            <argument type="service" id="bitbag.repository.shipping_export" />
+            <argument type="service" id="session.flash_bag" />
+
+            <tag name="bitbag.inpost_shipping_export_action" priority="-1024" />
+        </service>
+
+        <service
+            id="bitbag.sylius_inpost_plugin.provider.inpost_shipping_export_action"
+            class="BitBag\SyliusInPostPlugin\EventListener\ShippingExportEventListener\InPostShippingExportActionProvider"
+        >
+            <argument type="tagged_iterator" tag="bitbag.inpost_shipping_export_action" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/translations/flashes.en.yml
+++ b/src/Resources/translations/flashes.en.yml
@@ -1,0 +1,3 @@
+bitbag:
+    ui:
+        shipment_data_has_been_marked_as_pending: Shipment has been marked as pending. External provider's system is still processing a label. Please wait a few minutes before you try again.

--- a/tests/Spec/Builder/OrderBuilder.php
+++ b/tests/Spec/Builder/OrderBuilder.php
@@ -28,9 +28,16 @@ class OrderBuilder
         $this->order = new Order();
     }
 
-    public function withShipment(ShipmentInterface $shipment): self
+    public function withShipment(ShipmentInterface $shipment):OrderBuilder
     {
         $this->order->addShipment($shipment);
+
+        return $this;
+    }
+
+    public function withNumber(string $number): OrderBuilder
+    {
+        $this->order->setNumber($number);
 
         return $this;
     }

--- a/tests/Spec/Builder/ShipmentBuilder.php
+++ b/tests/Spec/Builder/ShipmentBuilder.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Tests\BitBag\SyliusInPostPlugin\Spec\Builder;
 
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Shipment;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
@@ -28,9 +29,16 @@ class ShipmentBuilder
         $this->shipment = new Shipment();
     }
 
-    public function withShippingMethod(ShippingMethodInterface $shippingMethod): self
+    public function withShippingMethod(ShippingMethodInterface $shippingMethod): ShipmentBuilder
     {
         $this->shipment->setMethod($shippingMethod);
+
+        return $this;
+    }
+
+    public function withOrder(OrderInterface $order): ShipmentBuilder
+    {
+        $this->shipment->setOrder($order);
 
         return $this;
     }

--- a/tests/Spec/Builder/ShippingExportBuilder.php
+++ b/tests/Spec/Builder/ShippingExportBuilder.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusInPostPlugin\Spec\Builder;
+
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExport;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingGatewayInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+
+class ShippingExportBuilder
+{
+    private ShippingExportInterface $shippingExport;
+
+    public static function create(): ShippingExportBuilder
+    {
+        return new self();
+    }
+
+    private function __construct()
+    {
+        $this->shippingExport = new ShippingExport();
+    }
+
+    public function withShipment(ShipmentInterface $shipment): ShippingExportBuilder
+    {
+        $this->shippingExport->setShipment($shipment);
+
+        return $this;
+    }
+
+    public function withExternalId(string $id): ShippingExportBuilder
+    {
+        $this->shippingExport->setExternalId($id);
+
+        return $this;
+    }
+
+    public function withShippingGateway(ShippingGatewayInterface $shippingGateway): ShippingExportBuilder
+    {
+        $this->shippingExport->setShippingGateway($shippingGateway);
+
+        return $this;
+    }
+
+    public function build(): ShippingExportInterface
+    {
+        return $this->shippingExport;
+    }
+}

--- a/tests/Spec/Builder/ShippingGatewayBuilder.php
+++ b/tests/Spec/Builder/ShippingGatewayBuilder.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+ */
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusInPostPlugin\Spec\Builder;
+
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingGateway;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingGatewayInterface;
+
+class ShippingGatewayBuilder
+{
+    private ShippingGatewayInterface $shippingGateway;
+
+    public static function create(): ShippingGatewayBuilder
+    {
+        return new self();
+    }
+
+    private function __construct()
+    {
+        $this->shippingGateway = new ShippingGateway();
+    }
+
+    public function withCode(string $code): ShippingGatewayBuilder
+    {
+        $this->shippingGateway->setCode($code);
+
+        return $this;
+    }
+
+    public function build():ShippingGatewayInterface
+    {
+        return $this->shippingGateway;
+    }
+}


### PR DESCRIPTION
With `1.6` version of our `ShippingExport` plugin we've introduced a `Pending` state for a shipping export entry.

This PR introduces this state in our InPost plugin to handle a case when InPost doesn't generate a label on time and we need to handle this situation somehow. This PR in such cases saves InPost external ID of shipment and uses it in a next time to check if the label is ready to download.

![2022-02-16 12 40 06 PM](https://user-images.githubusercontent.com/80641364/154257532-f4cdaa5c-fd80-40b9-bb3a-21b66ec73a05.gif)

