### PR TITLE
Add controller.service_arguments tag on AddPointToOrderController service

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,6 +41,8 @@
             <argument type="service" id="sylius.manager.order"/>
             <argument type="service" id="bitbag.sylius_inpost_plugin.api.web_client"/>
             <argument type="service" id="sylius.context.cart"/>
+
+            <tag name="controller.service_arguments" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
While refactoring we probably removed `public: true` default value for all services (what of course is a good practice) but we didn't notice the controller has no `controller.service_arguments` tag so it couldn't be resolved. This PR fixes this issue :).